### PR TITLE
Tweak and consolidate onboarding message text

### DIFF
--- a/lib/onboarding-message.coffee
+++ b/lib/onboarding-message.coffee
@@ -1,0 +1,38 @@
+module.exports = \
+"""
+Hello, and welcome to Data for Democracy's Slack workspace! This is where we \
+all hang out, collaborate, and discuss how we can use data and technology to \
+make positive changes in communities around the world.
+
+Please take a moment to review our *Code of Conduct* here:
+https://github.com/Data4Democracy/read-this-first/blob/master/Code-of-Conduct.md
+
+Before you jump in, we'd also love for you to sign our *Global Data Ethics \
+Pledge*. The Pledge is a sort of Hippocratic Oath, but for data workers \
+instead of medical practitioners. To learn more, visit \
+https://www.datafordemocracy.org/pledge.
+
+:hatching_chick::hatching_chick: *SOME HELPFUL TIPS* :hatching_chick::hatching_chick:
+
+_*Introduce yourself!*_
+We love meeting new people. Head over to #onboarding and tell us a little \
+about yourself. Things that are great to include are the types of projects you \
+are interested in working on and any relevant technology experience you have. \
+Don't be intimidated if you're just getting started -- there are always \
+plenty of non-technical roles to fill!
+
+_*Ready to help out with one of our ongoing projects?*_
+Our most active projects are listed near the top of our GitHub home page at \
+https://github.com/Data4Democracy. You'll find more information on how to get \
+started inside each project's repository. Once you've found one to pique your \
+interest, head over to its corresponding Slack channel and ask about ways to \
+get involved!
+
+_*Want to start your own project?*_
+Full documentation on starting a project and becoming a project lead can be \
+found at https://github.com/Data4Democracy/project-ideas. You can also pitch \
+your idea in #project-ideas to get feedback from the community!
+
+In the meantime our friendly bot, Data, is always around and here to help! \
+Message @Data with 'help' to see a list of all the things it can do for you.
+"""

--- a/scripts/commands.coffee
+++ b/scripts/commands.coffee
@@ -16,6 +16,9 @@
 #   hubot !nonprofit - Details D4D's nonprofit status
 #   hubot !feedback - Instructions of how to leave feedback and report bugs for the slackbot
 #   hubot !onboard - Displays onboarding instructions
+
+onboardingMessage = require('../lib/onboarding-message')
+
 module.exports = (robot) ->
 
   robot.hear /!conduct/i, (res) ->
@@ -42,4 +45,4 @@ module.exports = (robot) ->
     res.send "Data for Democracy applied for independent non-profit status in early 2018 and receives grant funds and donations through its fiscal sponsor, The Hopewell Fund. We have recently convened a community body to seek board members. If you are interested, please email team@datafordemocracy.org"
 
   robot.hear /!onboard/i, (res) ->
-    res.send "Hello, and welcome to Data for Democracy's Slack workspace! This is where we all hang out, collaborate, and discuss how we can use data and technology to make positive changes in communities around the world.\n\nPlease take a moment to review our Code of Conduct here https://github.com/Data4Democracy/read-this-first/blob/master/Code-of-Conduct.md \n\nBefore you jump in, we'd love for you to sign our *Global Data Ethics Pledge*. The Pledge is a sort of Hippocratic Oath, but for data workers instead of medical practitioners. To learn more, visit https://www.datafordemocracy.org/pledge \n\n - *Introduce yourself!* We love meeting new people. Head over to #onboarding and tell us a little about yourself. Things that are great to include are the types of projects you are interested in working on and any relevant technology experience you have. Don't be intimidated if you are just getting started, there are plenty of non-technical roles to fill as well.\n\n- *Ready to help out with one of our ongoing projects?* If you look here the most active projects will always be near the top.https://github.com/Data4Democracy Inside the project you will find information on how to get started. You can then head over to the slack channel for that project and ask about ways to get involved. \n\n- *Want to start your own project?* Full documentation on starting a project can be found at https://github.com/Data4Democracy/project-ideas. You can also post in #project-ideas to get more feedback. Make sure to review the information here about becoming a project lead.\n\n In the meantime, Data is always around and here to help! Message @Data with 'help' to see a list of all the things it can do for you."
+    res.send onboardingMessage

--- a/scripts/welcome.coffee
+++ b/scripts/welcome.coffee
@@ -9,11 +9,12 @@
 #
 # Commands:
 
+onboardingMessage = require('../lib/onboarding-message')
+
 module.exports = (robot) ->
   conversationId = "C3S64JPTM"
   robot.enter (res) ->
     if res.message.room == conversationId
-      enterReply = "Hello, and welcome to Data for Democracy's Slack workspace! This is where we all hang out, collaborate, and discuss how we can use data and technology to make positive changes in communities around the world.\n\nPlease take a moment to review our Code of Conduct here https://github.com/Data4Democracy/read-this-first/blob/master/Code-of-Conduct.md \n\nBefore you jump in, we'd love for you to sign our *Global Data Ethics Pledge*. The Pledge is a sort of Hippocratic Oath, but for data workers instead of medical practitioners. To learn more, visit https://www.datafordemocracy.org/pledge \n\n - *Introduce yourself!* We love meeting new people. Head over to #onboarding and tell us a little about yourself. Things that are great to include are the types of projects you are interested in working on and any relevant technology experience you have. Don't be intimidated if you are just getting started, there are plenty of non-technical roles to fill as well.\n\n- *Ready to help out with one of our ongoing projects?* If you look here the most active projects will always be near the top.https://github.com/Data4Democracy Inside the project you will find information on how to get started. You can then head over to the slack channel for that project and ask about ways to get involved. \n\n- *Want to start your own project?* Full documentation on starting a project can be found at https://github.com/Data4Democracy/project-ideas. You can also post in #project-ideas to get more feedback. Make sure to review the information here about becoming a project lead.\n\n In the meantime, Data is always around and here to help! Message @Data with 'help' to see a list of all the things it can do for you."
       room = robot.adapter.client.rtm.dataStore.getDMByName res.message.user.name
-      robot.messageRoom room.id, enterReply
+      robot.messageRoom room.id, onboardingMessage
 


### PR DESCRIPTION
This commit moves onboarding message text into its own file
(located at `lib/onboarding-message.coffee`), which lets us re-use
it across multiple scripts without repeating. (Currently it's used
in both `scripts/welcome.coffee` and `scripts/commands.coffee`).

It also slightly tweaks verbiage and formatting, both to make
things "prettier" for users and to make it easier to read in a
text editor, should we need to come back and make changes later.